### PR TITLE
feat(kernel): scaffold Makefile and module skeleton

### DIFF
--- a/kernel-module/Makefile
+++ b/kernel-module/Makefile
@@ -1,0 +1,10 @@
+KDIR ?= /lib/modules/$(shell uname -r)/build
+SRC := $(shell pwd)/src
+
+all:
+	$(MAKE) -C $(KDIR) M=$(SRC) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(SRC) clean
+
+.PHONY: all clean

--- a/kernel-module/src/Makefile
+++ b/kernel-module/src/Makefile
@@ -1,0 +1,1 @@
+obj-m += edge_sensor.o

--- a/kernel-module/src/edge_sensor.c
+++ b/kernel-module/src/edge_sensor.c
@@ -1,0 +1,22 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Cloud2Edge");
+MODULE_DESCRIPTION("Edge sensor telemetry via procfs");
+MODULE_VERSION("0.1.0");
+
+static int __init edge_sensor_init(void)
+{
+	pr_info("edge_sensor: module loaded\n");
+	return 0;
+}
+
+static void __exit edge_sensor_exit(void)
+{
+	pr_info("edge_sensor: module unloaded\n");
+}
+
+module_init(edge_sensor_init);
+module_exit(edge_sensor_exit);


### PR DESCRIPTION
## Closes #1

## What Changed
- Added `kernel-module/src/edge_sensor.c` — minimal module with init/exit and printk
- Added `kernel-module/src/Makefile` — kbuild object directive
- Added `kernel-module/Makefile` — top-level wrapper for out-of-tree build

## How to Test
```bash
cd kernel-module && make
modinfo src/edge_sensor.ko
```

## Checklist
- [x] Conventional commit messages
- [x] Tests pass locally
- [ ] VERSION bumped (if applicable)
- [ ] CHANGELOG.md updated