### PR TITLE
test(rust-agent): unit + integration tests

### DIFF
--- a/rust-agent/Cargo.lock
+++ b/rust-agent/Cargo.lock
@@ -83,9 +83,11 @@ name = "edge-agent"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "http-body-util",
  "serde",
  "serde_json",
  "tokio",
+ "tower",
 ]
 
 [[package]]

--- a/rust-agent/Cargo.toml
+++ b/rust-agent/Cargo.toml
@@ -8,3 +8,7 @@ tokio = { version = "1", features = ["full"] }
 axum = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"

--- a/rust-agent/src/lib.rs
+++ b/rust-agent/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod telemetry;
+pub mod server;

--- a/rust-agent/src/main.rs
+++ b/rust-agent/src/main.rs
@@ -1,60 +1,9 @@
-use axum::{Json, Router, http::StatusCode, routing::get};
-use serde::Serialize;
-use std::fs;
+use edge_agent::server;
 use tokio::net::TcpListener;
-
-const PROC_PATH: &str = "/proc/edge_sensor";
-
-#[derive(Debug, Serialize)]
-pub struct Telemetry {
-    pub cpu_temp_c: i32,
-    pub mem_pressure_pct: i32,
-    pub tcp_retrans_segs: i64,
-}
-
-pub fn read_telemetry() -> Result<Telemetry, String> {
-    let content = fs::read_to_string(PROC_PATH)
-        .map_err(|e| format!("failed to read {}: {}", PROC_PATH, e))?;
-
-    let mut cpu_temp_c: Option<i32> = None;
-    let mut mem_pressure_pct: Option<i32> = None;
-    let mut tcp_retrans_segs: Option<i64> = None;
-
-    for line in content.lines() {
-        let Some((key, val)) = line.split_once('=') else {
-            continue;
-        };
-        match key {
-            "cpu_temp_c" => cpu_temp_c = val.parse().ok(),
-            "mem_pressure_pct" => mem_pressure_pct = val.parse().ok(),
-            "tcp_retrans_segs" => tcp_retrans_segs = val.parse().ok(),
-            _ => {}
-        }
-    }
-
-    Ok(Telemetry {
-        cpu_temp_c: cpu_temp_c.ok_or("missing cpu_temp_c")?,
-        mem_pressure_pct: mem_pressure_pct.ok_or("missing mem_pressure_pct")?,
-        tcp_retrans_segs: tcp_retrans_segs.ok_or("missing tcp_retrans_segs")?,
-    })
-}
-
-async fn get_telemetry() -> Result<Json<Telemetry>, (StatusCode, String)> {
-    read_telemetry()
-        .map(Json)
-        .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e))
-}
-
-async fn health() -> &'static str {
-    "ok"
-}
 
 #[tokio::main]
 async fn main() {
-    let app = Router::new()
-        .route("/telemetry", get(get_telemetry))
-        .route("/health", get(health));
-
+    let app = server::build_router();
     let addr = "0.0.0.0:3000";
     println!("edge-agent listening on {}", addr);
 

--- a/rust-agent/src/server.rs
+++ b/rust-agent/src/server.rs
@@ -1,0 +1,18 @@
+use axum::{Json, Router, http::StatusCode, routing::get};
+use crate::telemetry::{Telemetry, read_telemetry};
+
+async fn get_telemetry() -> Result<Json<Telemetry>, (StatusCode, String)> {
+    read_telemetry()
+        .map(Json)
+        .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e))
+}
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+pub fn build_router() -> Router {
+    Router::new()
+        .route("/telemetry", get(get_telemetry))
+        .route("/health", get(health))
+}

--- a/rust-agent/src/telemetry.rs
+++ b/rust-agent/src/telemetry.rs
@@ -1,0 +1,89 @@
+use serde::Serialize;
+use std::fs;
+
+const PROC_PATH: &str = "/proc/edge_sensor";
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct Telemetry {
+    pub cpu_temp_c: i32,
+    pub mem_pressure_pct: i32,
+    pub tcp_retrans_segs: i64,
+}
+
+pub fn parse_telemetry(content: &str) -> Result<Telemetry, String> {
+    let mut cpu_temp_c: Option<i32> = None;
+    let mut mem_pressure_pct: Option<i32> = None;
+    let mut tcp_retrans_segs: Option<i64> = None;
+
+    for line in content.lines() {
+        let Some((key, val)) = line.split_once('=') else {
+            continue;
+        };
+        match key {
+            "cpu_temp_c" => cpu_temp_c = val.parse().ok(),
+            "mem_pressure_pct" => mem_pressure_pct = val.parse().ok(),
+            "tcp_retrans_segs" => tcp_retrans_segs = val.parse().ok(),
+            _ => {}
+        }
+    }
+
+    Ok(Telemetry {
+        cpu_temp_c: cpu_temp_c.ok_or("missing cpu_temp_c")?,
+        mem_pressure_pct: mem_pressure_pct.ok_or("missing mem_pressure_pct")?,
+        tcp_retrans_segs: tcp_retrans_segs.ok_or("missing tcp_retrans_segs")?,
+    })
+}
+
+pub fn read_telemetry() -> Result<Telemetry, String> {
+    let content = fs::read_to_string(PROC_PATH)
+        .map_err(|e| format!("failed to read {}: {}", PROC_PATH, e))?;
+    parse_telemetry(&content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_input() {
+        let input = "cpu_temp_c=47\nmem_pressure_pct=65\ntcp_retrans_segs=14934\n";
+        let t = parse_telemetry(input).unwrap();
+        assert_eq!(t, Telemetry {
+            cpu_temp_c: 47,
+            mem_pressure_pct: 65,
+            tcp_retrans_segs: 14934,
+        });
+    }
+
+    #[test]
+    fn test_parse_negative_values() {
+        let input = "cpu_temp_c=-1\nmem_pressure_pct=-1\ntcp_retrans_segs=-1\n";
+        let t = parse_telemetry(input).unwrap();
+        assert_eq!(t, Telemetry {
+            cpu_temp_c: -1,
+            mem_pressure_pct: -1,
+            tcp_retrans_segs: -1,
+        });
+    }
+
+    #[test]
+    fn test_parse_missing_key() {
+        let input = "cpu_temp_c=47\nmem_pressure_pct=65\n";
+        let err = parse_telemetry(input).unwrap_err();
+        assert_eq!(err, "missing tcp_retrans_segs");
+    }
+
+    #[test]
+    fn test_parse_ignores_unknown_keys() {
+        let input = "cpu_temp_c=50\nmem_pressure_pct=40\ntcp_retrans_segs=100\nunknown_key=999\n";
+        let t = parse_telemetry(input).unwrap();
+        assert_eq!(t.cpu_temp_c, 50);
+    }
+
+    #[test]
+    fn test_parse_invalid_value() {
+        let input = "cpu_temp_c=abc\nmem_pressure_pct=65\ntcp_retrans_segs=100\n";
+        let err = parse_telemetry(input).unwrap_err();
+        assert_eq!(err, "missing cpu_temp_c");
+    }
+}

--- a/rust-agent/tests/integration.rs
+++ b/rust-agent/tests/integration.rs
@@ -1,0 +1,33 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use edge_agent::server::build_router;
+
+#[tokio::test]
+async fn test_health_endpoint() {
+    let app = build_router();
+    let req = Request::builder()
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"ok");
+}
+
+#[tokio::test]
+async fn test_telemetry_endpoint_unavailable() {
+    if std::path::Path::new("/proc/edge_sensor").exists() {
+        return;
+    }
+    let app = build_router();
+    let req = Request::builder()
+        .uri("/telemetry")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}


### PR DESCRIPTION
## Closes #7

## What Changed
- Refactored into modules: `telemetry.rs`, `server.rs`, `lib.rs`, `main.rs`
- 5 unit tests in `telemetry.rs` (parsing logic)
- 2 integration tests in `tests/integration.rs` (HTTP endpoints via tower::ServiceExt)
- Added `tower` and `http-body-util` as dev dependencies

## How to Test
```bash
cd rust-agent && cargo test
```

## Checklist
- [x] Conventional commit messages
- [x] Tests pass locally
- [ ] VERSION bumped (if applicable)
- [ ] CHANGELOG.md updated