### PR TITLE
feat(mcp): implement get_telemetry tool

### DIFF
--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -1,6 +1,25 @@
+import httpx
 from mcp.server.fastmcp import FastMCP
 
+AGENT_URL = "http://localhost:3000"
+
 mcp = FastMCP("edge-mcp-server")
+
+
+@mcp.tool()
+async def get_telemetry() -> str:
+    """Get current edge device telemetry (CPU temp, memory pressure, TCP retransmits)."""
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(f"{AGENT_URL}/telemetry", timeout=5.0)
+            if resp.status_code == 200:
+                return resp.text
+            return f"agent returned {resp.status_code}: {resp.text}"
+        except httpx.ConnectError:
+            return "error: cannot reach rust-agent at localhost:3000"
+        except httpx.TimeoutException:
+            return "error: rust-agent request timed out"
+
 
 if __name__ == "__main__":
     mcp.run()


### PR DESCRIPTION
## Closes #9

## What Changed
- Added `get_telemetry` MCP tool
- Queries rust-agent HTTP endpoint, returns JSON telemetry
- Handles connection errors and timeouts gracefully

## How to Test
```bash
cd mcp-server && source .venv/bin/activate
python -c "
import asyncio
from src.server import get_telemetry
print(asyncio.run(get_telemetry()))
"
```

## Checklist
- [x] Conventional commit messages
- [x] Tests pass locally
- [ ] VERSION bumped (if applicable)
- [ ] CHANGELOG.md updated