### PR TITLE
feat(deploy): Dockerfile for rust-agent

### DIFF
--- a/deploy/docker/Dockerfile.agent
+++ b/deploy/docker/Dockerfile.agent
@@ -1,0 +1,23 @@
+# Stage 1: Build
+FROM rust:1.95-bookworm AS builder
+
+WORKDIR /build
+COPY rust-agent/Cargo.toml rust-agent/Cargo.lock ./
+COPY rust-agent/src ./src
+
+RUN cargo build --release
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/edge-agent /usr/local/bin/edge-agent
+
+EXPOSE 3000
+
+# Note: container needs host procfs mounted at /proc/edge_sensor
+# In k3s: hostPath volume or privileged mode with the kernel module loaded on the host
+CMD ["edge-agent"]


### PR DESCRIPTION
## Closes #12

## What Changed
- Multi-stage Dockerfile: `rust:1.95-bookworm` build → `debian:bookworm-slim` runtime
- Only the release binary is copied to the final image
- Exposes port 3000
- Note: requires host procfs mounted for /proc/edge_sensor access

## How to Test
```bash
sudo docker build -f deploy/docker/Dockerfile.agent -t cloud2edge/rust-agent:0.2.0 .
sudo docker run --rm -v /proc/edge_sensor:/proc/edge_sensor:ro -p 3000:3000 cloud2edge/rust-agent:0.2.0
```

## Checklist
- [x] Conventional commit messages
- [x] Tests pass locally
- [ ] VERSION bumped (if applicable)
- [ ] CHANGELOG.md updated