### PR TITLE
feat(deploy): Dockerfile for mcp-server

### DIFF
--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -1,0 +1,14 @@
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app
+
+COPY mcp-server/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY mcp-server/src ./src
+
+# MCP server uses stdio transport by default.
+# For remote access, override CMD with: python src/server.py --transport sse
+EXPOSE 8080
+
+CMD ["python", "src/server.py"]


### PR DESCRIPTION
## Closes #13

## What Changed
- Added `deploy/docker/Dockerfile.mcp`
- Python 3.12 slim base, pip install, copy source
- Exposes 8080 for SSE transport option

## How to Test
```bash
sudo docker build -f deploy/docker/Dockerfile.mcp -t cloud2edge/mcp-server:0.2.0 .
```

## Checklist
- [x] Conventional commit messages
- [x] Tests pass locally
- [ ] VERSION bumped (if applicable)
- [ ] CHANGELOG.md updated