### PR TITLE
feat(deploy): k3s manifests

### DIFF
--- a/deploy/k3s/agent-deployment.yaml
+++ b/deploy/k3s/agent-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-agent
+  namespace: cloud2edge
+  labels:
+    app: edge-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: edge-agent
+  template:
+    metadata:
+      labels:
+        app: edge-agent
+    spec:
+      containers:
+        - name: edge-agent
+          image: cloud2edge/rust-agent:0.2.0
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: proc-edge-sensor
+              mountPath: /proc/edge_sensor
+              readOnly: true
+          resources:
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+      volumes:
+        - name: proc-edge-sensor
+          hostPath:
+            path: /proc/edge_sensor
+            type: File
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-agent
+  namespace: cloud2edge
+spec:
+  selector:
+    app: edge-agent
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/deploy/k3s/configmap.yaml
+++ b/deploy/k3s/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edge-config
+  namespace: cloud2edge
+data:
+  AGENT_URL: "http://edge-agent:3000"
+  CPU_TEMP_THRESHOLD: "80"
+  MEM_PRESSURE_THRESHOLD: "90"
+  TCP_RETRANS_THRESHOLD: "50000"

--- a/deploy/k3s/mcp-deployment.yaml
+++ b/deploy/k3s/mcp-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-server
+  namespace: cloud2edge
+  labels:
+    app: mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-server
+  template:
+    metadata:
+      labels:
+        app: mcp-server
+    spec:
+      containers:
+        - name: mcp-server
+          image: cloud2edge/mcp-server:0.2.0
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: edge-config
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-server
+  namespace: cloud2edge
+spec:
+  selector:
+    app: mcp-server
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/deploy/k3s/namespace.yaml
+++ b/deploy/k3s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloud2edge

--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -1,8 +1,9 @@
 import asyncio
+import os
 import httpx
 from mcp.server.fastmcp import FastMCP
 
-AGENT_URL = "http://localhost:3000"
+AGENT_URL = os.environ.get("AGENT_URL", "http://localhost:3000")
 
 mcp = FastMCP("edge-mcp-server")
 


### PR DESCRIPTION
## Closes #14

## What Changed
- `deploy/k3s/namespace.yaml` — cloud2edge namespace
- `deploy/k3s/configmap.yaml` — AGENT_URL + threshold values
- `deploy/k3s/agent-deployment.yaml` — Rust agent pod + service, hostPath mount for procfs
- `deploy/k3s/mcp-deployment.yaml` — MCP server pod + service, reads config from ConfigMap
- Updated `mcp-server/src/server.py` to read AGENT_URL from env (k3s compatible)

## How to Test
```bash
# Validate manifests
kubectl apply --dry-run=client -f deploy/k3s/

# Deploy to k3s
kubectl apply -f deploy/k3s/
```

## Checklist
- [x] Conventional commit messages
- [x] Tests pass locally
- [ ] VERSION bumped (if applicable)
- [ ] CHANGELOG.md updated